### PR TITLE
Add `checkoutPassportItemForPayload` API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
 	getPassportItemForPayload as getPassportItemFromPayload,
 	PLUGIN_ID,
 	checkoutPassportItems,
+	checkoutPassportItemForPayload,
 } from './utils'
 
 import {
@@ -71,6 +72,7 @@ export {
 	SchemaKey,
 	PLUGIN_ID,
 	checkoutPassportItems,
+	checkoutPassportItemForPayload,
 	type CreatePassportItemReq,
 	sTokenPayload,
 	type PassportItemAssetType,

--- a/src/utils/checkoutPassportItems.ts
+++ b/src/utils/checkoutPassportItems.ts
@@ -69,7 +69,7 @@ export const checkoutPassportItemForPayload = async (
 	)
 
 	// eslint-disable-next-line functional/no-expression-statements
-	await whenDefined(client, (r) => r.quit())
+	whenDefined(client, (r) => r.quit())
 
 	const paymentsDebugMode = Boolean(
 		config.plugins
@@ -149,7 +149,7 @@ export const checkoutPassportItems = async (
 	)) as CheckoutFromPassportOffering
 
 	// eslint-disable-next-line functional/no-expression-statements
-	await whenDefined(client, (r) => r.quit())
+	whenDefined(client, (r) => r.quit())
 
 	return returnObject
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,7 +6,10 @@ import {
 	addPassportItemSetter,
 } from './passportItem'
 
-import { checkoutPassportItems } from './checkoutPassportItems'
+import {
+	checkoutPassportItems,
+	checkoutPassportItemForPayload,
+} from './checkoutPassportItems'
 
 export const PLUGIN_ID = 'devprotocol:clubs:plugin:passports'
 
@@ -29,6 +32,7 @@ export {
 	getPassportItemForPayload,
 	addPassportItemSetter,
 	checkoutPassportItems,
+	checkoutPassportItemForPayload,
 }
 
 export default {


### PR DESCRIPTION
By using `checkoutPassportItemForPayload` API, the caller can be fetched complete offering object including fiat prices, discount prices (if exists) for Passport item.