### PR TITLE
Add mute option to media embed components

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -146,6 +146,7 @@ export type MediaProps = {
 	embedOptions?: {
 		autoplay?: boolean
 		lock?: boolean
+		mute?: boolean
 	}
 	class?: string
 	imageClass?: string

--- a/src/vue/Media.vue
+++ b/src/vue/Media.vue
@@ -91,6 +91,7 @@ async function updateImageIfNeeded() {
 			:class="`${className ? className : ''} ${embedClass ? embedClass : ''}`"
 			:autoplay="embedOptions?.autoplay"
 			:lock="embedOptions?.lock"
+			:mute="embedOptions?.mute"
 		/>
 		<div
 			v-if="image && !imageLoaded"

--- a/src/vue/MediaEmbed.vue
+++ b/src/vue/MediaEmbed.vue
@@ -53,17 +53,17 @@ onMounted(() => {
 	window.addEventListener('message', (event) => {
 		if (
 			event.data &&
-			event.data["x-tiktok-player"] &&
-			event.data.type === "onReady" &&
+			event.data['x-tiktok-player'] &&
+			event.data.type === 'onReady' &&
 			!mute &&
 			type.value === EmbeddableMediaType.TikTok
 		) {
 			tiktokRef.value?.contentWindow?.postMessage(
-				{ type: "onMute", value: false, "x-tiktok-player": true },
-				'*'
-			);
+				{ type: 'onMute', value: false, 'x-tiktok-player': true },
+				'*',
+			)
 		}
-	});
+	})
 })
 
 watch(_src, (__src) => {

--- a/src/vue/MediaEmbed.vue
+++ b/src/vue/MediaEmbed.vue
@@ -21,6 +21,7 @@ const type = computed<EmbeddableMediaType | Error>(() => mediaSource(src))
 const mediaId = computed<string | undefined>(() => getMediaId(src))
 const mounted = ref(false)
 const elmX = useTemplateRef('twttr')
+const tiktokRef = useTemplateRef<HTMLIFrameElement>('tiktok-player')
 const _src = computed(() => src)
 
 const load = (src: string) => {
@@ -48,6 +49,21 @@ onMounted(() => {
 		}
 	})
 	load(src)
+
+	window.addEventListener('message', (event) => {
+		if (
+			event.data &&
+			event.data["x-tiktok-player"] &&
+			event.data.type === "onReady" &&
+			!mute &&
+			type.value === EmbeddableMediaType.TikTok
+		) {
+			tiktokRef.value?.contentWindow?.postMessage(
+				{ type: "onMute", value: false, "x-tiktok-player": true },
+				'*'
+			);
+		}
+	});
 })
 
 watch(_src, (__src) => {
@@ -87,6 +103,7 @@ watch(_src, (__src) => {
 
 	<iframe
 		v-if="type === EmbeddableMediaType.TikTok"
+		ref="tiktok-player"
 		:src="`https://www.tiktok.com/player/v1/${mediaId}?autoplay=${autoplay ? 1 : 0}&controls=0&play_button=0&loop=1&timestamp=0`"
 		allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
 		referrerpolicy="strict-origin-when-cross-origin"

--- a/src/vue/MediaEmbed.vue
+++ b/src/vue/MediaEmbed.vue
@@ -8,11 +8,13 @@ const {
 	class: className,
 	autoplay = true,
 	lock = false,
+	mute = true,
 } = defineProps<{
 	src: string
 	class?: string
 	autoplay?: boolean
 	lock?: boolean
+	mute?: boolean
 }>()
 
 const type = computed<EmbeddableMediaType | Error>(() => mediaSource(src))
@@ -63,7 +65,7 @@ watch(_src, (__src) => {
 
 	<iframe
 		v-if="type === EmbeddableMediaType.YouTube"
-		:src="`https://www.youtube.com/embed/${mediaId}?playlist=${mediaId}&autoplay=${autoplay ? 1 : 0}&mute=1&loop=1`"
+		:src="`https://www.youtube.com/embed/${mediaId}?playlist=${mediaId}&autoplay=${autoplay ? 1 : 0}&mute=${mute ? 1 : 0}&loop=1`"
 		allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
 		referrerpolicy="strict-origin-when-cross-origin"
 		allowfullscreen
@@ -74,7 +76,7 @@ watch(_src, (__src) => {
 
 	<iframe
 		v-if="type === EmbeddableMediaType.YouTubeShorts"
-		:src="`https://www.youtube.com/embed/${mediaId}?playlist=${mediaId}&autoplay=${autoplay ? 1 : 0}&mute=1&loop=1`"
+		:src="`https://www.youtube.com/embed/${mediaId}?playlist=${mediaId}&autoplay=${autoplay ? 1 : 0}&mute=${mute ? 1 : 0}&loop=1`"
 		allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
 		referrerpolicy="strict-origin-when-cross-origin"
 		allowfullscreen


### PR DESCRIPTION
Implemented a `mute` property to control muting for embedded media, particularly YouTube videos. Updated relevant props, iframe logic, and type definitions to support this feature.