### PR TITLE
Fix TikTok embed unmute functionality

### DIFF
--- a/src/vue/MediaEmbed.vue
+++ b/src/vue/MediaEmbed.vue
@@ -54,13 +54,13 @@ onMounted(() => {
 		if (
 			event.data &&
 			event.data['x-tiktok-player'] &&
-			event.data.type === 'onReady' &&
+			event.data.type === 'onPlayerReady' &&
 			!mute &&
 			type.value === EmbeddableMediaType.TikTok
 		) {
 			tiktokRef.value?.contentWindow?.postMessage(
-				{ type: 'onMute', value: false, 'x-tiktok-player': true },
-				'*',
+				{ type: 'unMute', 'x-tiktok-player': true },
+				'*'
 			)
 		}
 	})


### PR DESCRIPTION
Updated message type from 'onMute' to 'unMute' and corrected the event type to 'onPlayerReady' to properly handle unmute behavior for TikTok embeds. This ensures the player receives the correct message and behaves as expected.